### PR TITLE
wrap metadata in Content.Json

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,7 @@ object Build extends Build {
     private def apply(x: String) = "com.typesafe.akka" %% s"akka-$x" % "2.3.4"
   }
 
-  val eventstoreClient   = "com.geteventstore" %% "eventstore-client" % "1.0.0-SNAPSHOT"
+  val eventstoreClient   = "com.geteventstore" %% "eventstore-client" % "0.5.1-SNAPSHOT"
   val specs2             = "org.specs2" %% "specs2" % "2.3.11" % "test"
   val persistenceTestkit = "com.github.krasserm" %% "akka-persistence-testkit" % "0.3.3" % "test"
   val json4s             = "org.json4s" %% "json4s-native" % "3.2.9"

--- a/src/main/scala/akka/persistence/eventstore/journal/EventStoreJournal.scala
+++ b/src/main/scala/akka/persistence/eventstore/journal/EventStoreJournal.scala
@@ -36,7 +36,7 @@ class EventStoreJournal extends AsyncWriteJournal with EventStorePlugin {
       else deleteToCache.get(persistenceId).fold(s"""{"$TruncateBefore":$to}""") {
         deleteTo => s"""{"$TruncateBefore":$to,"$DeleteTo":$deleteTo}"""
       }
-    val eventData = EventData.StreamMetadata(json)
+    val eventData = EventData.StreamMetadata(Content.Json(json))
     val streamId = eventStream(persistenceId).metadata
     val req = WriteEvents(streamId, List(eventData))
     connection.future(req)


### PR DESCRIPTION
Not sure which snapshot version of the EventStore/EventStore.JVM you were on, but for syncing up with master I had to wrap the metadata parameter.
