### PR TITLE
build: add eventstore-docker for it:test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,23 @@
 language: scala
 scala:
-  - 2.12.3
-  - 2.11.11
+  - 2.12.4
+  - 2.11.12
+
+env:
+  global:
+    - AKKA_TEST_TIMEFACTOR=2.0
+
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  - docker pull eventstore/eventstore
+  - docker run -d --rm --name eventstore-node -it -p 2113:2113 -p 1113:1113 -e EVENTSTORE_START_STANDARD_PROJECTIONS=True eventstore/eventstore
+
 script:
-  - travis_retry sbt test
+  - travis_retry sbt test it:test
+
 jdk:
   - oraclejdk8

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -1,9 +1,15 @@
 akka {
+
   loglevel = "ERROR"
   log-dead-letters = off
   log-dead-letters-during-shutdown = off
+
+  test.timefactor = 1.0
+  test.timefactor = ${?AKKA_TEST_TIMEFACTOR}
+
   persistence {
     journal.plugin = eventstore.persistence.journal
     snapshot-store.plugin = eventstore.persistence.snapshot-store
   }
+
 }

--- a/src/it/scala/akka/persistence/eventstore/journal/JournalPerfIntegrationSpec.scala
+++ b/src/it/scala/akka/persistence/eventstore/journal/JournalPerfIntegrationSpec.scala
@@ -7,5 +7,8 @@ import scala.concurrent.duration._
 
 class JournalPerfIntegrationSpec extends JournalPerfSpec(ConfigFactory.load()) with EventStorePluginSpec {
 
+  override def awaitDurationMillis: Long = 30.seconds.toMillis
+  override def eventsCount: Int = 2500
+
   def supportsRejectingNonSerializableObjects = false
 }


### PR DESCRIPTION
 - lower expectations wrt. performance tests, because
   sync persist tests take *long* time to complete.

 - make read journal test less brittle.

 - add akka test timefactor.

 - change travis build file to run it:test and use eventstore
   docker.