### PR TITLE
deps: bump es client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,31 @@
-language: scala
-scala:
-  - 2.12.8
-  - 2.11.12
+jdk:
+  - oraclejdk8
 
-env:
-  global:
-    - AKKA_TEST_TIMEFACTOR=2.0
+language: scala
+
+scala:
+  - 2.13.0
+  - 2.12.8
 
 sudo: required
 
 services:
   - docker
 
-before_install:
-  - docker pull eventstore/eventstore
-  - docker run -d --rm --name eventstore-node -it -p 2113:2113 -p 1113:1113 -e EVENTSTORE_START_STANDARD_PROJECTIONS=True eventstore/eventstore
-
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test it:test
+  - sbt ++$TRAVIS_SCALA_VERSION test:compile it:compile test
 
-jdk:
-  - oraclejdk8
+jobs:
+  include:
+    - stage: integration
+      scala: 2.13.0
+      env: AKKA_TEST_TIMEFACTOR=2.0 AKKA_TEST_LOGLEVEL=OFF
+      before_install:
+        - docker pull eventstore/eventstore:release-5.0.1
+        - docker run -d --rm --name eventstore-node -it -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 -e EVENTSTORE_START_STANDARD_PROJECTIONS=True eventstore/eventstore:release-5.0.1
+      script:
+        - sbt test:compile
+        - travis_retry sbt it:test
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-### Event Store Plugin for Akka Persistence [![Build Status](https://travis-ci.org/EventStore/EventStore.Akka.Persistence.svg?branch=master)](https://travis-ci.org/EventStore/EventStore.Akka.Persistence) [![Version](https://img.shields.io/maven-central/v/com.geteventstore/akka-persistence-eventstore_2.11.svg?label=version)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Acom.geteventstore%20AND%20akka-persistence-eventstore)
+### Event Store Plugin for Akka Persistence [![Build Status](https://travis-ci.org/EventStore/EventStore.Akka.Persistence.svg?branch=master)](https://travis-ci.org/EventStore/EventStore.Akka.Persistence) [![Version](https://img.shields.io/maven-central/v/com.geteventstore/akka-persistence-eventstore_2.13.svg?label=version)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Acom.geteventstore%20AND%20akka-persistence-eventstore)
 
 [Akka Persistence](http://doc.akka.io/docs/akka/2.5.21/scala/persistence.html) journal and snapshot-store backed by [Event Store](http://geteventstore.com/).
 
 <table border="0">
   <tr>
     <td><a href="http://www.scala-lang.org">Scala</a> </td>
-    <td>2.12.8/2.11.12</td>
+    <td>2.13.0 / 2.12.8</td>
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.5.21</td>
+    <td>2.5.23</td>
   </tr>
   <tr>
     <td><a href="https://github.com/EventStore/EventStore.JVM">EventStore client</a> </td>
-    <td>6.0.0</td>
+    <td>7.0.1</td>
   </tr>
 </table>
 
@@ -51,7 +51,7 @@ Please check out some real examples used in tests:
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "6.0.0"
+libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "7.0.0"
 ```
 
 #### Maven
@@ -59,6 +59,6 @@ libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "6
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>akka-persistence-eventstore_${scala.version}</artifactId>
-    <version>6.0.0</version>
+    <version>7.0.0</version>
 </dependency>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.geteventstore"
 
 scalaVersion := crossScalaVersions.value.last
 
-crossScalaVersions := Seq("2.11.12", "2.12.8")
+crossScalaVersions := Seq("2.12.8", "2.13.0")
 
 releaseCrossBuild := true
 
@@ -18,24 +18,16 @@ description := "Event Store Plugin for Akka Persistence"
 
 startYear := Some(2013)
 
-scalacOptions ++= Seq(
-  "-encoding", "UTF-8",
-  "-feature",
-  "-unchecked",
-  "-deprecation",
-  "-Xfatal-warnings",
-  "-Xlint:-missing-interpolator",
-  "-Yno-adapted-args",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-Xfuture"
-)
+scalacOptions ++= Seq("-target:jvm-1.8")
+javacOptions  ++= Seq("-target", "8", "-source", "8")
+scalacOptions --= Seq("-Ywarn-unused:params", "-Wunused:params")
+Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings")
 
-scalacOptions in(Compile, doc) ++= Seq("-groups", "-implicits", "-no-link-warnings")
+///
 
 resolvers += "spray" at "http://repo.spray.io/"
 
-val AkkaVersion = "2.5.21"
+val AkkaVersion = "2.5.23"
 
 lazy val IntegrationTest = config("it") extend Test
 
@@ -46,9 +38,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.geteventstore" %% "eventstore-client" % "6.0.0",
-  "org.specs2" %% "specs2-core" % "4.4.1" % Test,
-  "org.json4s" %% "json4s-native" % "3.6.5" % Test,
+  "com.geteventstore" %% "eventstore-client" % "7.0.1",
+  "org.specs2" %% "specs2-core" % "4.5.1" % Test,
+  "org.json4s" %% "json4s-native" % "3.6.6" % Test,
   "io.spray" %%  "spray-json" % "1.3.5")
 
 lazy val root = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")

--- a/src/it/scala/akka/persistence/eventstore/ActorSpec.scala
+++ b/src/it/scala/akka/persistence/eventstore/ActorSpec.scala
@@ -3,7 +3,7 @@ package akka.persistence.eventstore
 import akka.actor.ActorSystem
 import akka.testkit.{ ImplicitSender, TestKit }
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ WordSpecLike, BeforeAndAfterAll, FlatSpec }
+import org.scalatest.{ WordSpecLike, BeforeAndAfterAll }
 
 class ActorSpec extends WordSpecLike with BeforeAndAfterAll {
   implicit lazy val system: ActorSystem = ActorSystem(getClass.getSimpleName, config)

--- a/src/it/scala/akka/persistence/eventstore/Json4sSerializer.scala
+++ b/src/it/scala/akka/persistence/eventstore/Json4sSerializer.scala
@@ -7,8 +7,8 @@ import akka.actor.{ ActorRef, ExtendedActorSystem }
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent.Snapshot
 import akka.persistence.{ PersistentRepr, SnapshotMetadata }
-import akka.util.ByteString
-import eventstore.{ Content, ContentType, Event, EventData }
+import eventstore.core.util.uuid.randomUuid
+import eventstore.{Content, ByteString, ContentType, Event, EventData}
 import org.json4s.Extraction.decompose
 import org.json4s._
 import org.json4s.native.Serialization.{ read, write }
@@ -35,11 +35,13 @@ class Json4sSerializer(val system: ExtendedActorSystem) extends EventStoreSerial
   def toEvent(x: AnyRef) = x match {
     case x: PersistentRepr => EventData(
       eventType = classFor(x).getName,
+      eventId = randomUuid,
       data = Content(ByteString(toBinary(x)), ContentType.Json)
     )
 
     case x: SnapshotEvent => EventData(
       eventType = classFor(x).getName,
+      eventId = randomUuid,
       data = Content(ByteString(toBinary(x)), ContentType.Json)
     )
 
@@ -54,7 +56,7 @@ class Json4sSerializer(val system: ExtendedActorSystem) extends EventStoreSerial
   }
 
   def classFor(x: AnyRef) = x match {
-    case x: PersistentRepr => classOf[PersistentRepr]
+    case _: PersistentRepr => classOf[PersistentRepr]
     case _                 => x.getClass
   }
 

--- a/src/it/scala/akka/persistence/eventstore/SprayJsonSerializer.scala
+++ b/src/it/scala/akka/persistence/eventstore/SprayJsonSerializer.scala
@@ -2,16 +2,14 @@ package akka.persistence.eventstore
 
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-
+import scala.reflect.ClassTag
 import akka.actor.ExtendedActorSystem
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent.Snapshot
 import akka.persistence.{ PersistentRepr, SnapshotMetadata }
-import akka.util.ByteString
-import eventstore.{ Content, ContentType, Event, EventData }
+import eventstore.core.util.uuid.randomUuid
+import eventstore.{ Content, ByteString, ContentType, Event, EventData}
 import spray.json._
-
-import scala.reflect.ClassTag
 
 class SprayJsonSerializer(val system: ExtendedActorSystem) extends EventStoreSerializer {
   import SprayJsonSerializer._
@@ -41,11 +39,13 @@ class SprayJsonSerializer(val system: ExtendedActorSystem) extends EventStoreSer
   def toEvent(x: AnyRef) = x match {
     case x: PersistentRepr => EventData(
       eventType = classFor(x).getName,
+      eventId = randomUuid,
       data = Content(ByteString(toBinary(x)), ContentType.Json)
     )
 
     case x: SnapshotEvent => EventData(
       eventType = classFor(x).getName,
+      eventId = randomUuid,
       data = Content(ByteString(toBinary(x)), ContentType.Json)
     )
 
@@ -60,7 +60,7 @@ class SprayJsonSerializer(val system: ExtendedActorSystem) extends EventStoreSer
   }
 
   def classFor(x: AnyRef) = x match {
-    case x: PersistentRepr => classOf[PersistentRepr]
+    case _: PersistentRepr => classOf[PersistentRepr]
     case _                 => x.getClass
   }
 }

--- a/src/it/scala/akka/persistence/eventstore/query/EventStoreReadJournalIntegrationSpec.scala
+++ b/src/it/scala/akka/persistence/eventstore/query/EventStoreReadJournalIntegrationSpec.scala
@@ -29,7 +29,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
       expectNoMessage(100.millis) // Give ES some time to write to $streams
 
       val src = queries.persistenceIds().filter { x => persistenceIds contains x }
-      val probe = src.runWith(TestSink.probe[String])
+      src.runWith(TestSink.probe[String])
         .request(persistenceIds.size.toLong)
         .expectNextUnorderedN(persistenceIds)
     }
@@ -59,7 +59,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find existing events" in new Scope {
       val envelopes = write(10) take 5
       val src = queries.eventsByPersistenceId(persistenceId, 0, Long.MaxValue)
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(5)
         .expectNextN(envelopes)
     }
@@ -67,7 +67,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find new events" in new Scope {
       val src = queries.eventsByPersistenceId(persistenceId, 0, Long.MaxValue)
       val envelopes = write(10) take 5
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(5)
         .expectNextN(envelopes)
     }
@@ -75,7 +75,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find existing events in defined range" in new Scope {
       val envelopes = write(10).slice(1, 3)
       val src = queries.eventsByPersistenceId(persistenceId, 1, 3)
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(3)
         .expectNextN(envelopes)
     }
@@ -83,7 +83,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find new events in defined range" in new Scope {
       val src = queries.eventsByPersistenceId(persistenceId, 1, 3)
       val envelopes = write(10).slice(1, 3)
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(3)
         .expectNextN(envelopes)
     }
@@ -94,7 +94,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find events" in new Scope {
       val envelopes = write(5)
       val src = queries.currentEventsByPersistenceId(persistenceId, 0, Long.MaxValue)
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(5)
         .expectNextN(envelopes)
         .expectComplete()
@@ -110,7 +110,7 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
     "find events in defined range" in new Scope {
       val envelopes = write(5).slice(1, 3)
       val src = queries.currentEventsByPersistenceId(persistenceId, 1, 3)
-      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      src.runWith(TestSink.probe[EventEnvelope])
         .request(3)
         .expectNextN(envelopes)
         .expectComplete()
@@ -151,11 +151,11 @@ class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
 
     class TestActor(val persistenceId: String) extends PersistentActor {
 
-      val receiveRecover: Receive = { case evt: String ⇒ }
+      val receiveRecover: Receive = { case _: String => }
 
       val receiveCommand: Receive = {
-        case cmd: String ⇒
-          persist(cmd) { evt ⇒
+        case cmd: String =>
+          persist(cmd) { evt =>
             sender() ! evt + "-done"
           }
       }

--- a/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
+++ b/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
@@ -3,14 +3,14 @@ package akka.persistence.eventstore
 import akka.actor.{ Actor, ActorLogging }
 import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
-import eventstore._
-import eventstore.tcp.ConnectionActor
-
+import eventstore.akka.Settings
+import eventstore.akka._
+import eventstore.akka.tcp.ConnectionActor
 import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 trait EventStorePlugin extends ActorLogging { self: Actor =>
-  val settings = Settings(context.system.settings.config)
+  val settings: Settings = Settings(context.system.settings.config)
 
   val connection: EsConnection = {
     val dispatcher = config.getString("plugin-dispatcher")

--- a/src/main/scala/akka/persistence/eventstore/EventStoreSerialization.scala
+++ b/src/main/scala/akka/persistence/eventstore/EventStoreSerialization.scala
@@ -1,10 +1,10 @@
 package akka.persistence.eventstore
 
+import scala.reflect.ClassTag
 import akka.actor.ActorSystem
 import akka.serialization.{ Serialization, SerializationExtension }
-import eventstore.{ Content, Event, EventData }
-
-import scala.reflect.ClassTag
+import eventstore.core.util.uuid.randomUuid
+import eventstore.{ Content, Event, EventData}
 
 case class EventStoreSerialization(serialization: Serialization) {
   def deserialize[T](event: Event)(implicit tag: ClassTag[T]): T = {
@@ -22,6 +22,7 @@ case class EventStoreSerialization(serialization: Serialization) {
       case ser: EventStoreSerializer => ser.toEvent(data)
       case _ => EventData(
         eventType = (eventType getOrElse data).getClass.getName,
+        eventId = randomUuid,
         data = Content(ser.toBinary(data))
       )
     }

--- a/src/main/scala/akka/persistence/eventstore/Helpers.scala
+++ b/src/main/scala/akka/persistence/eventstore/Helpers.scala
@@ -1,7 +1,7 @@
 package akka.persistence.eventstore
 
 import eventstore._
-
+import eventstore.akka.EsConnection
 import scala.annotation.tailrec
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/src/main/scala/akka/persistence/eventstore/query/scaladsl/EventStoreReadJournal.scala
+++ b/src/main/scala/akka/persistence/eventstore/query/scaladsl/EventStoreReadJournal.scala
@@ -1,5 +1,6 @@
 package akka.persistence.eventstore.query.scaladsl
 
+import scala.util.control.NonFatal
 import akka.NotUsed
 import akka.actor.ExtendedActorSystem
 import akka.event.Logging
@@ -10,9 +11,8 @@ import akka.persistence.query._
 import akka.persistence.query.scaladsl._
 import akka.stream.scaladsl.Source
 import com.typesafe.config.Config
-import eventstore.{ EventNumber, EventStoreExtension, EventStream }
-
-import scala.util.control.NonFatal
+import eventstore.akka.EventStoreExtension
+import eventstore.core.{ EventNumber, EventStream }
 
 class EventStoreReadJournal(system: ExtendedActorSystem, config: Config)
     extends ReadJournal

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "6.0.1-SNAPSHOT"
+version in ThisBuild := "7.0.0-SNAPSHOT"


### PR DESCRIPTION
 - upgrade es client and make adjustments with respect to
   package changes and `ByteString`.

 - remove 2.11.x support.

 - add support for Scala 2.13.0 and adjust code
   accordingly wrt. deprecation warnings.

 - add tpolecat plugin.

 - change `asyncWriteMessages` in `EventStoreJournal` to use
   `List` instead of `Traversable` as it is deprecated in
   Scala 2.13.0 and causes compile error. The deprecation warning
   suggests to use `Iterable` instead, but that causes stack
   overflow in "may serialize events" test in
   `JournalPerfIntegrationSpec` in Scala 2.12.8. Using `List`
   solves the issue.

 - adjust docker setup to use in-memory db and change stats
   period in order to avoid interference with tests.

 - adjust travis to run integration tests for Scala 2.13.0 and
   otherwise compile code and tests for Scala 2.12.8 and 2.13.0.

 - set version to `7.0.0-SNAPSHOT` as es client version
   `7.0.1` has breaking changes, as well as removal of 
    Scala 2.11.x support, this is considered a breaking change.

 - bump dependencies.