### PR TITLE
build: move deps forward + ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ target
 .idea/
 *.iml
 
+# Metals
+.metals/*
+.bloop/*
+project/.bloop/*
+project/metals.sbt
+
 # Mac
 .DS_Store
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 language: scala
 
 scala:
-  - 2.13.0
-  - 2.12.9
+  - 2.13.1
+  - 2.12.10
 
 sudo: required
 
@@ -18,11 +18,11 @@ script:
 jobs:
   include:
     - stage: integration
-      scala: 2.13.0
+      scala: 2.13.1
       env: AKKA_TEST_TIMEFACTOR=2.0 AKKA_TEST_LOGLEVEL=OFF
       before_install:
-        - docker pull eventstore/eventstore:release-5.0.2
-        - docker run -d --rm --name eventstore-node -it -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 -e EVENTSTORE_START_STANDARD_PROJECTIONS=True eventstore/eventstore:release-5.0.2
+        - docker pull eventstore/eventstore:release-5.0.5
+        - docker run -d --rm --name eventstore-node -it -p 2113:2113 -p 1113:1113 -e EVENTSTORE_MEM_DB=True -e EVENTSTORE_STATS_PERIOD_SEC=1200 -e EVENTSTORE_START_STANDARD_PROJECTIONS=True eventstore/eventstore:release-5.0.5
       script:
         - sbt test:compile
         - travis_retry sbt it:test

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 <table border="0">
   <tr>
     <td><a href="http://www.scala-lang.org">Scala</a> </td>
-    <td>2.13.0 / 2.12.9</td>
+    <td>2.13.1 / 2.12.10</td>
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.5.25</td>
+    <td>2.6.1</td>
   </tr>
   <tr>
     <td><a href="https://github.com/EventStore/EventStore.JVM">EventStore client</a> </td>
-    <td>7.0.2</td>
+    <td>7.1.0</td>
   </tr>
 </table>
 
@@ -51,7 +51,7 @@ Please check out some real examples used in tests:
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "7.0.1"
+libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "7.1.0"
 ```
 
 #### Maven

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.geteventstore"
 
 scalaVersion := crossScalaVersions.value.last
 
-crossScalaVersions := Seq("2.12.9", "2.13.0")
+crossScalaVersions := Seq("2.12.10", "2.13.1")
 
 releaseCrossBuild := true
 
@@ -25,9 +25,7 @@ Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warning
 
 ///
 
-resolvers += "spray" at "http://repo.spray.io/"
-
-val AkkaVersion = "2.5.25"
+val AkkaVersion = "2.6.1"
 
 lazy val IntegrationTest = config("it") extend Test
 
@@ -38,10 +36,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.geteventstore" %% "eventstore-client" % "7.0.2",
-  "org.specs2" %% "specs2-core" % "4.7.0" % Test,
+  "com.geteventstore" %% "eventstore-client" % "7.1.0",
+  "org.specs2" %% "specs2-core" % "4.8.3" % Test,
   "org.json4s" %% "json4s-native" % "3.6.7" % Test,
-  "io.spray" %%  "spray-json" % "1.3.5")
+  "io.spray" %% "spray-json" % "1.3.5"
+)
 
 lazy val root = (project in file("."))
   .configs(IntegrationTest)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.10")

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -7,6 +7,8 @@ akka {
   test.timefactor = 1.0
   test.timefactor = ${?AKKA_TEST_TIMEFACTOR}
 
+  actor.allow-java-serialization = true
+
   persistence {
     journal.plugin = eventstore.persistence.journal
     snapshot-store.plugin = eventstore.persistence.snapshot-store

--- a/src/it/scala/akka/persistence/eventstore/query/EventStoreReadJournalIntegrationSpec.scala
+++ b/src/it/scala/akka/persistence/eventstore/query/EventStoreReadJournalIntegrationSpec.scala
@@ -7,12 +7,10 @@ import akka.persistence.PersistentActor
 import akka.persistence.eventstore.ActorSpec
 import akka.persistence.eventstore.query.scaladsl.EventStoreReadJournal
 import akka.persistence.query.{EventEnvelope, PersistenceQuery, Sequence}
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
 import org.scalatest.Matchers
 
 class EventStoreReadJournalIntegrationSpec extends ActorSpec with Matchers {
-  implicit val materializer = ActorMaterializer()
 
   def queries = PersistenceQuery(system).
     readJournalFor[EventStoreReadJournal](EventStoreReadJournal.Identifier)

--- a/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
+++ b/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
@@ -1,7 +1,6 @@
 package akka.persistence.eventstore
 
-import akka.actor.{ Actor, ActorLogging }
-import akka.stream.ActorMaterializer
+import akka.actor.{Actor, ActorLogging}
 import com.typesafe.config.Config
 import eventstore.akka.Settings
 import eventstore.akka._
@@ -16,11 +15,11 @@ trait EventStorePlugin extends ActorLogging { self: Actor =>
     val dispatcher = config.getString("plugin-dispatcher")
     val props = ConnectionActor.props(settings).withDispatcher(dispatcher)
     val ref = context.actorOf(props, "eventstore")
+    import context.system
     new EsConnection(ref, context, settings)
   }
 
   val serialization = EventStoreSerialization(context.system)
-  implicit val materializer = ActorMaterializer()(context)
   val prefix: String = config.getString("stream-prefix")
   import context.dispatcher
 

--- a/src/main/scala/akka/persistence/eventstore/journal/EventStoreJournal.scala
+++ b/src/main/scala/akka/persistence/eventstore/journal/EventStoreJournal.scala
@@ -124,6 +124,8 @@ class EventStoreJournal extends AsyncWriteJournal with EventStorePlugin {
     max:           Long
   )(recoveryCallback: PersistentRepr => Unit): Future[Unit] = {
 
+    import context.system
+
     def replayMany(from: Option[EventNumber.Exact], to: EventNumber.Exact): Future[Unit] = Future {
       val streamId = eventStream(persistenceId)
       connection.streamSource(streamId, from, infinite = false, readBatchSize = readBatchSize)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.0.2-SNAPSHOT"
+version in ThisBuild := "7.1.0-SNAPSHOT"


### PR DESCRIPTION
  - migrate to Akka 2.6.1 + ES client 7.1 and adjust
    code accordingly in order to avoid deprecation
    warnings and make tests pass.

  - remove unnecessary resolver for spray.

  - change CI to use openjdk8 & bump scala + ES docker image

  - bump scala + sbt / tpolecat plugin