### PR TITLE
all: Scala3 support

### DIFF
--- a/.docker/esdb.yml
+++ b/.docker/esdb.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
 
   esdb:
-    image: eventstore/eventstore:21.10.0-bionic
+    image: eventstore/eventstore:21.10.1-bionic
     environment:
       - EVENTSTORE_MEM_DB=True
       - EVENTSTORE_INSECURE=True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.7, 2.12.15]
+        scala: [3.1.0, 2.13.7, 2.12.15]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,7 +31,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: sbt ++${{ matrix.scala }} test:compile test
+          command: sbt ++${{ matrix.scala }} 'Test/compile; test'
 
   esdb:
     name: Integration Tests
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.7]
+        scala: [3.1.0, 2.13.7, 2.12.15]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -62,7 +62,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: sbt ++${{ matrix.scala }} it:test
+          command: sbt ++${{ matrix.scala }} 'It/test'
 
       - name: Stop ESDB
         if: always()
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.7]
+        scala: [3.1.0, 2.13.7, 2.12.15]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,7 +100,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: sbt ++${{ matrix.scala }} it:test
+          command: sbt ++${{ matrix.scala }} 'It/test'
 
       - name: Stop Legacy ESDB
         if: always()

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 <table border="0">
   <tr>
     <td><a href="http://www.scala-lang.org">Scala</a> </td>
-    <td>2.13.7 / 2.12.15</td>
+    <td>3.1.0 / 2.13.7 / 2.12.15</td>
   </tr>
   <tr>
     <td><a href="http://akka.io">Akka</a> </td>
-    <td>2.6.17</td>
+    <td>2.6.18</td>
   </tr>
   <tr>
     <td><a href="https://github.com/EventStore/EventStore.JVM">EventStore client</a> </td>
-    <td>7.4.0</td>
+    <td>8.0.0</td>
   </tr>
 </table>
 
@@ -51,7 +51,7 @@ Please check out some real examples used in tests:
 
 #### Sbt
 ```scala
-libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "7.2.3"
+libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "8.0.0"
 ```
 
 #### Maven
@@ -59,6 +59,6 @@ libraryDependencies += "com.geteventstore" %% "akka-persistence-eventstore" % "7
 <dependency>
     <groupId>com.geteventstore</groupId>
     <artifactId>akka-persistence-eventstore_${scala.version}</artifactId>
-    <version>7.2.3</version>
+    <version>8.0.0</version>
 </dependency>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,12 @@
+lazy val isScala3 = Def.setting(CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3))
+
 name := "akka-persistence-eventstore"
 
 organization := "com.geteventstore"
 
 scalaVersion := crossScalaVersions.value.last
 
-crossScalaVersions := Seq("2.12.15", "2.13.7")
+crossScalaVersions := Seq("2.12.15", "2.13.7", "3.1.0")
 
 releaseCrossBuild := true
 
@@ -18,36 +20,42 @@ description := "Event Store Plugin for Akka Persistence"
 
 startYear := Some(2013)
 
-scalacOptions ++= Seq("-target:jvm-1.8")
+scalacOptions ++= { if (isScala3.value) Seq("-Xtarget:8") else Seq("-target:jvm-1.8") }
 javacOptions  ++= Seq("-target", "8", "-source", "8")
-scalacOptions --= Seq("-Ywarn-unused:params", "-Wunused:params", "-Wunused:explicits")
+scalacOptions --= Seq("-Ywarn-unused:params", "-Wunused:params", "-Wunused:explicits", "-Wunused:nowarn")
 Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings")
 
 ///
 
-val AkkaVersion = "2.6.17"
+val ClientVersion = "8.0.0"
+val CirceVersion = "0.14.1"
+val AkkaVersion = "2.6.18"
 
 lazy val IntegrationTest = config("it") extend Test
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.geteventstore" %% "eventstore-client" % ClientVersion,
+  "io.circe" %% "circe-core" % CirceVersion,
+  "io.circe" %% "circe-parser" % CirceVersion,
+  "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.geteventstore" %% "eventstore-client" % "7.4.0",
-  "org.specs2" %% "specs2-core" % "4.13.0" % Test,
-  "org.json4s" %% "json4s-native" % "3.6.10" % Test,
-  "io.spray" %% "spray-json" % "1.3.6"
+   // akka-persistence-query relies on akka-remote via QuerySerializer, however it uses "provided".
+  "com.typesafe.akka" %% "akka-remote" % AkkaVersion % Test,
+  ("org.specs2" %% "specs2-core" % "4.13.1").cross(CrossVersion.for3Use2_13) % Test,
+  "org.json4s" %% "json4s-native" % "4.0.3" % Test,
+  "io.spray" %% "spray-json" % "1.3.6" % Test
 )
 
 lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
-  .settings(parallelExecution in IntegrationTest := false)
+  .settings(IntegrationTest / parallelExecution := false)
 
-pomExtra in Global := {
+Global / pomExtra := {
   <scm>
     <url>git@github.com:EventStore/EventStore.Akka.Persistence.git</url>
     <connection>scm:git:git@github.com:EventStore/EventStore.Akka.Persistence.git</connection>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.16")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.20")

--- a/src/it/scala/akka/persistence/eventstore/Json4sSerializer.scala
+++ b/src/it/scala/akka/persistence/eventstore/Json4sSerializer.scala
@@ -3,6 +3,7 @@ package akka.persistence.eventstore
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 
+import scala.annotation.nowarn
 import akka.actor.{ ActorRef, ExtendedActorSystem }
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent
 import akka.persistence.eventstore.snapshot.EventStoreSnapshotStore.SnapshotEvent.Snapshot
@@ -16,13 +17,14 @@ import org.json4s.native.Serialization.{ read, write }
 class Json4sSerializer(val system: ExtendedActorSystem) extends EventStoreSerializer {
   import Json4sSerializer._
 
-  implicit val formats = DefaultFormats + SnapshotSerializer + new PersistentReprSerializer(system) + ActorRefSerializer
+  implicit val formats: Formats = 
+    DefaultFormats + SnapshotSerializer + new PersistentReprSerializer(system) + ActorRefSerializer
 
-  def identifier = Identifier
+  def identifier: Int = Identifier
 
-  def includeManifest = true
+  def includeManifest: Boolean = true
 
-  def fromBinary(bytes: Array[Byte], manifestOpt: Option[Class[_]]) = {
+  def fromBinary(bytes: Array[Byte], manifestOpt: Option[Class[_]]): AnyRef = {
     implicit val manifest = manifestOpt match {
       case Some(x) => Manifest.classType(x)
       case None    => Manifest.AnyRef
@@ -30,9 +32,9 @@ class Json4sSerializer(val system: ExtendedActorSystem) extends EventStoreSerial
     read(new String(bytes, UTF8))
   }
 
-  def toBinary(o: AnyRef) = write(o).getBytes(UTF8)
+  def toBinary(o: AnyRef): Array[Byte] = write(o).getBytes(UTF8)
 
-  def toEvent(x: AnyRef) = x match {
+  def toEvent(x: AnyRef): EventData = x match {
     case x: PersistentRepr => EventData(
       eventType = classFor(x).getName,
       eventId = randomUuid,
@@ -48,20 +50,20 @@ class Json4sSerializer(val system: ExtendedActorSystem) extends EventStoreSerial
     case _ => sys.error(s"Cannot serialize $x, SnapshotEvent expected")
   }
 
-  def fromEvent(event: Event, manifest: Class[_]) = {
+  def fromEvent(event: Event, manifest: Class[_]): AnyRef = {
     val clazz = Class.forName(event.data.eventType)
     val result = fromBinary(event.data.data.value.toArray, clazz)
     if (manifest.isInstance(result)) result
     else sys.error(s"Cannot deserialize event as $manifest, event: $event")
   }
 
-  def classFor(x: AnyRef) = x match {
+  private def classFor(x: AnyRef) = x match {
     case _: PersistentRepr => classOf[PersistentRepr]
     case _                 => x.getClass
   }
 
   object ActorRefSerializer extends Serializer[ActorRef] {
-    val Clazz = classOf[ActorRef]
+    private val Clazz = classOf[ActorRef]
 
     def deserialize(implicit format: Formats) = {
       case (TypeInfo(Clazz, _), JString(x)) => system.provider.resolveActorRef(x)
@@ -77,24 +79,45 @@ object Json4sSerializer {
   val UTF8: Charset = Charset.forName("UTF-8")
   val Identifier: Int = ByteBuffer.wrap("json4s".getBytes(UTF8)).getInt
 
-  object SnapshotSerializer extends Serializer[Snapshot] {
-    val Clazz = classOf[Snapshot]
 
-    def deserialize(implicit format: Formats) = {
-      case (TypeInfo(Clazz, _), JObject(List(
-        JField("data", JString(x)),
-        JField("metadata", metadata)))) => Snapshot(x, metadata.extract[SnapshotMetadata])
+  object SnapshotMeatadataFormat extends JsonFormat[SnapshotMetadata] {
+
+    def readUnsafe(value: JValue): SnapshotMetadata =
+      readEither(value).fold(throw _, identity)
+
+    def readEither(value: JValue): Either[MappingException, SnapshotMetadata] = value match {
+      case JObject(JField("persistenceId", JString(pid)) :: JField("sequenceNr", JInt(sn)) :: JField("timestamp", JInt(ts)) :: Nil) =>
+        Right(SnapshotMetadata(pid, sn.longValue, ts.longValue))
+      case m =>
+        Left(new MappingException(s"Unknown json: $m"))
     }
 
-    def serialize(implicit format: Formats) = {
-      case Snapshot(data, metadata) => JObject("data" -> JString(data.toString), "metadata" -> decompose(metadata))
+    def write(sm: SnapshotMetadata): JValue = JObject(
+      JField("persistenceId", JString(sm.persistenceId)),
+      JField("sequenceNr", JLong(sm.sequenceNr)),
+      JField("timestamp", JLong(sm.timestamp))
+    )
+  }
+
+  object SnapshotSerializer extends Serializer[Snapshot] {
+    val Clazz: Class[Snapshot] = classOf[Snapshot]
+
+    def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), Snapshot] = {
+      case (TypeInfo(Clazz, _), JObject(List(
+        JField("data", JString(x)),
+        JField("metadata", metadata)))) => Snapshot(x, SnapshotMeatadataFormat.readUnsafe(metadata))
+    }
+
+    def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+      case Snapshot(data, metadata) => JObject("data" -> JString(data.toString), "metadata" -> SnapshotMeatadataFormat.write(metadata))
     }
   }
 
   class PersistentReprSerializer(system: ExtendedActorSystem) extends Serializer[PersistentRepr] {
-    val Clazz = classOf[PersistentRepr]
+    val Clazz: Class[PersistentRepr] = classOf[PersistentRepr]
 
-    def deserialize(implicit format: Formats) = {
+    @nowarn
+    def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), PersistentRepr] = {
       case (TypeInfo(Clazz, _), json) =>
         val x = json.extract[Mapping]
         PersistentRepr(
@@ -105,7 +128,7 @@ object Json4sSerializer {
           writerUuid = x.writerUuid
         )
     }
-    def serialize(implicit format: Formats) = {
+    def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
       case x: PersistentRepr =>
         val mapping = Mapping(
           payload = x.payload.asInstanceOf[String],

--- a/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
+++ b/src/main/scala/akka/persistence/eventstore/EventStorePlugin.scala
@@ -15,7 +15,6 @@ trait EventStorePlugin extends ActorLogging { self: Actor =>
     val dispatcher = config.getString("plugin-dispatcher")
     val props = ConnectionActor.props(settings).withDispatcher(dispatcher)
     val ref = context.actorOf(props, "eventstore")
-    import context.system
     new EsConnection(ref, context, settings)
   }
 

--- a/src/main/scala/akka/persistence/eventstore/query/EventStoreReadJournalProvider.scala
+++ b/src/main/scala/akka/persistence/eventstore/query/EventStoreReadJournalProvider.scala
@@ -6,11 +6,11 @@ import com.typesafe.config.Config
 
 class EventStoreReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
 
-  val scaladslReadJournal: scaladsl.EventStoreReadJournal = {
+  def scaladslReadJournal(): scaladsl.EventStoreReadJournal = {
     new scaladsl.EventStoreReadJournal(system, config)
   }
 
-  val javadslReadJournal: javadsl.EventStoreReadJournal = {
-    new javadsl.EventStoreReadJournal(scaladslReadJournal)
+  def javadslReadJournal(): javadsl.EventStoreReadJournal = {
+    new javadsl.EventStoreReadJournal(scaladslReadJournal())
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "7.2.4-SNAPSHOT"
+ThisBuild / version := "7.2.4-SNAPSHOT"


### PR DESCRIPTION
 - change `EventStoreJournal` to to use circe as that is what is used in the jvm client.
 - change signature of `EventStoreReadJournalProvider` methods to match
   `ReadJournalProvider` from akka.
 - remove unused import from `EventStorePlugin`.

 - add `nowarn` annotation for `Json4sSerializer` as Scala 3 deprecates usage
   of `Manifest`.

 - define explicit `JsonFormat` for `SnapshotMetadata` due to Scala 3.

 - adjust ci setup.

 - upgrade various dependencies and adjust `README` to reflect changes.